### PR TITLE
hide title bar

### DIFF
--- a/menu.js
+++ b/menu.js
@@ -11,7 +11,7 @@ module.exports = function (onupdate) {
     height: 25px;
     width: 100%;
     font-size: 14px;
-    font-family: "Helvetica Neue";
+    font-family: sans-serif;
     font-weight: 200;
     outline: none;
     padding-left: 70px;

--- a/menu.js
+++ b/menu.js
@@ -14,6 +14,7 @@ module.exports = function (onupdate) {
     font-family: "Helvetica Neue";
     font-weight: 200;
     outline: none;
+    padding-left: 70px;
   }`
   var input = yo`<input class="${styles.input}" onkeydown=${onkeydown}></input>`
   menuEl.appendChild(input)

--- a/windows.js
+++ b/windows.js
@@ -16,6 +16,7 @@ function create () {
   var win = new electron.BrowserWindow({
     width: size.width,
     height: size.height,
+    titleBarStyle: 'hidden',
     title: 'Tabby'
   })
   win.loadURL(path.join('file://', __dirname, 'index.html'))


### PR DESCRIPTION
This PR hides the title bar on OS X 10.10 and above by setting the titleBarStyle to hidden.
