### PR TITLE
[ work in progress ] Add basic contextual menu

### DIFF
--- a/context-menu.js
+++ b/context-menu.js
@@ -1,0 +1,39 @@
+var remote = require('electron').remote
+var Menu = remote.Menu
+var MenuItem = remote.MenuItem
+
+var tabs = window.tabs
+
+function goBack () {
+  var tab = currentTab()
+  tab.goBack()
+}
+function reloadPage () {
+  var tab = currentTab()
+  tab.reload()
+}
+//function viewSource () {}
+//function savePage () {}
+//function printPage () {}
+//function inspectElement () {}
+
+function currentTab () {
+  for (var i = 0; i < tabs.length; i++) {
+    if (tabs[i].getAttribute('style').match('flex')) return tabs[i]
+  }
+}
+
+var menu = new Menu()
+menu.append(new MenuItem({ label: 'Back', click: goBack }))
+menu.append(new MenuItem({ label: 'Reload Page', click: reloadPage }))
+//menu.append(new MenuItem({ type: 'separator' }))
+//menu.append(new MenuItem({ label: 'Show Page Source', click: viewSource }))
+//menu.append(new MenuItem({ label: 'Save Page As', click: savePage }))
+//menu.append(new MenuItem({ label: 'Print Page', click: printPage }))
+//menu.append(new MenuItem({ type: 'separator' }))
+//menu.append(new MenuItem({ label: 'Inspect Element', click: inspectElement}))
+
+window.addEventListener('contextmenu', function (e) {
+  e.preventDefault()
+  menu.popup(remote.getCurrentWindow())
+}, false)

--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@
     <div class="tabs"></div>
     <script type="text/javascript">
       require('./renderer.js')()
+      require('./context-menu.js')()
     </script>
   </body>
 </html>


### PR DESCRIPTION
This patch introduces a basic contextual menu which contains _Back_ and
_Reload Page_ options.

This patch is a :construction: _work in progress_ :construction:. Any feedback
would be appreciated. I _think_ I'd like to have this code currently in
`./context-menu.js` within `./renderer.js` since most of the source is in there. My
own reluctance at first was that there was already a `Menu` variable using a custom
function for the address bar.

I've included some commented out functions I'd like to tackle to get a **better**
version of the contextual menu done. If I can get this in the `./renderer.js` file, I 
will also add the View Source, Save, and Print functions to the menubar.

:thought_balloon: Thoughts, opinions, etc welcome! :thought_balloon: 
