### PR TITLE
update dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "devDependencies": {
     "electron": "1.4.10",
-    "electron-packager": "^5.2.1",
+    "electron-packager": "^8.3.0",
     "standard": "^6.0.8"
   },
   "homepage": "https://github.com/maxogden/tabby",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "electron index.js",
     "test": "standard",
-    "build": "electron-packager . Tabby --platform=darwin --arch=x64 --version=0.36.11 --prune --icon=Icon.icns"
+    "build": "electron-packager . Tabby --platform=darwin --arch=x64 --version=1.4.10 --prune --icon=Icon.icns"
   },
   "standard": {
     "ignore": [
@@ -24,8 +24,8 @@
     "yo-yo": "^1.1.1"
   },
   "devDependencies": {
+    "electron": "1.4.10",
     "electron-packager": "^5.2.1",
-    "electron-prebuilt": "^0.36.11",
     "standard": "^6.0.8"
   },
   "homepage": "https://github.com/maxogden/tabby",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "devDependencies": {
     "electron": "1.4.10",
     "electron-packager": "^8.3.0",
-    "standard": "^6.0.8"
+    "standard": "^8.6.0"
   },
   "homepage": "https://github.com/maxogden/tabby",
   "bugs": {

--- a/renderer.js
+++ b/renderer.js
@@ -9,8 +9,8 @@ tld.defaultFile = path.join(__dirname, 'tlds.dat')
 var Menu = require('./menu.js')
 var pkg = require('./package.json')
 
-var errPage = 'file://' + __dirname + '/error.html'
-var newPage = 'file://' + __dirname + '/newtab.html'
+var errPage = 'file://' + path.join(__dirname, 'error.html')
+var newPage = 'file://' + path.join(__dirname, 'newtab.html')
 
 module.exports = function () {
   var menu = Menu(function onNewURL (href) {


### PR DESCRIPTION
Locks electron to 1.4.10, bumps standard and electron-packager. An update of #24 -- sorry it took so long to get to this!