### PR TITLE
add did-fail-load handler

### DIFF
--- a/renderer.js
+++ b/renderer.js
@@ -90,6 +90,13 @@ module.exports = function () {
     tab.addEventListener('did-get-response-details', function () {
       tab.__LOADFAIL = false
     })
+    tab.addEventListener('did-fail-load', function (e) {
+      var src = tab.getAttribute('src')
+      console.log('did-fail-load', src)
+      console.error('Error loading', src, e)
+      tab.setAttribute('src', errPage)
+      load.hide()
+    })
 
     var content = document.querySelector('.tabs')
     content.appendChild(tab)


### PR DESCRIPTION
Loading errors weren't getting handled correctly (blank page). Trying to load a page that doesn't exist or returns no response should now show the error page.